### PR TITLE
Add proxy support through the standard JRE proxy selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,13 +337,7 @@ Syntax:
 Define proxy settings for network calls made through a proxy server. 
 
 Syntax:
-> java -jar EyesUtilities.jar YOUR_EYES_UTILITIES_COMMAND -k [apiKey] -pu [YOUR_PROXY_URL] -pp [YOUR_PROXY_PORT] -pa [YOUR_PROXY_USERNAME,YOUR_PROXY_PASSWORD]
->
-+ Required parameters:
-    + `-pu [YOUR_PROXY_URL]` - The URL of the proxy server to route network requests through
-+ Optional parameters:
-    + `-pp [YOUR_PROXY_POT]` - Define a port if necessary (i.e. when making network requests directly to an explicit IP address)
-    + `-pa [YOUR_PROXY_USERNAME,YOUR_PROXY_PASSWORD]` - Define a username and password to communicate with proxy if necessary (comma separated)
+> java -Dhttps.proxyHost=[your proxy host] -Dhttps.proxyPort=[your proxy port] -jar EyesUtilities.jar YOUR_EYES_UTILITIES_COMMAND -k [apiKey]
 
 ## Resources
 + [Applitools website](https://applitools.com)

--- a/src/main/java/com/applitools/commands/CommandBase.java
+++ b/src/main/java/com/applitools/commands/CommandBase.java
@@ -1,35 +1,19 @@
 package com.applitools.commands;
 
 import com.beust.jcommander.Parameter;
-import com.beust.jcommander.converters.CommaParameterSplitter;
 
 import javax.net.ssl.*;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.List;
 
 public abstract class CommandBase implements Command {
     @Parameter(names = {"-dv"}, description = "Disable SSL certificate validation. !!!Unsecured!!!")
     private boolean disableCertificateValidation = false;
-    @Parameter(names = {"-pu", "-proxyUrl"}, description = "The URL for intermediary proxy if necessary")
-    private String proxyUrl;
-    @Parameter(names = {"-pp", "-proxyPort"}, description = "Port to use when sending proxy requests (when Url is an IP address)")
-    private String proxyPort;
-    @Parameter(
-            names = {"-pa", "-proxyAuth"},
-            description = "Username and password for auth communication. Pass arguments as \"username,password\")",
-            splitter = CommaParameterSplitter.class
-    )
-    List<String> proxyCredentials = new ArrayList<>();
 
     public void Execute() throws Exception {
         if (disableCertificateValidation)
             disableCertValidation();
-        if (proxyUrl != null) {
-            setProxy();
-        }
         run();
     }
 
@@ -62,23 +46,5 @@ public abstract class CommandBase implements Command {
 
         // Install the all-trusting host verifier
         HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
-    }
-
-    private void setProxy() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("Executing calls through proxy URL ").append(proxyUrl).append("\n");
-        System.setProperty("https.proxyHost", proxyUrl);
-
-        if (proxyPort != null) {
-            sb.append("Setting proxy port to ").append(proxyPort).append("\n");
-            System.setProperty("https.proxyPort", proxyPort);
-        }
-
-        if (proxyCredentials.size() > 0) {
-            sb.append("Setting proxy user for username ").append(proxyCredentials.get(0)).append("\n");
-            System.setProperty("https.proxyUser", proxyCredentials.get(0));
-            System.setProperty("https.ProxyPassword", proxyCredentials.get(1));
-        }
-        System.out.print(sb);
     }
 }

--- a/src/main/java/com/applitools/utils/ApiCallHandler.java
+++ b/src/main/java/com/applitools/utils/ApiCallHandler.java
@@ -7,15 +7,18 @@ import org.apache.http.client.methods.*;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 
 import java.io.IOException;
+import java.net.ProxySelector;
 
 public abstract class ApiCallHandler {
     private static final long INTERVAL_MULTIPLIER = 2;
     private static final int POLLING_RETRIES = 10;
     private static final String LOCATION_HEADER = "Location";
 
-    private static final CloseableHttpClient client = HttpClientBuilder.create().build();
+    private static final SystemDefaultRoutePlanner routePlanner = new SystemDefaultRoutePlanner(ProxySelector.getDefault());
+    private static final CloseableHttpClient client = HttpClientBuilder.create().setRoutePlanner(routePlanner).build();
 
     public static CloseableHttpResponse sendGetRequest(String uri, Context ctx) throws InterruptedException, IOException {
         HttpGet get = new HttpGet(uri);
@@ -60,6 +63,7 @@ public abstract class ApiCallHandler {
     }
 
     private static CloseableHttpResponse sendRequest(HttpRequestBase request) {
+
         try {
             CloseableHttpResponse result = client.execute(request);
             System.out.println(result.toString());


### PR DESCRIPTION
The proxy support added in 1.5.5 doesn't seem to work for us. It seems that Apache HttpClient doesn't respect the system or JVM proxy settings by default. Here is one solution to make it use `SystemDefaultRoutePlanner` as described here https://hc.apache.org/httpcomponents-client-4.5.x/current/tutorial/html/connmgmt.html#d5e485

We need this support for a project we are working on. Much appreciated. Thanks!